### PR TITLE
Fix/uppsf 666 update docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: /go/src/github.com/Financial-Times/concept-exporter
     docker:
-      - image: golang:1.8.3
+      - image: golang:1
         environment:
           GOPATH: /go
           CIRCLE_TEST_REPORTS: /tmp/test-results
@@ -50,7 +50,7 @@ jobs:
   dockerfile:
     working_directory: /concept-exporter
     docker:
-      - image: docker:1.12.6-git
+      - image: docker:18
     steps:
       - checkout
       - setup_docker_engine

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,32 @@
-FROM golang:1.8-alpine
+FROM golang:1
 
 ENV PROJECT=concept-exporter
-COPY . /${PROJECT}-sources/
 
-RUN apk --no-cache --virtual .build-dependencies add git \
-  && ORG_PATH="github.com/Financial-Times" \
-  && REPO_PATH="${ORG_PATH}/${PROJECT}" \
-  && mkdir -p $GOPATH/src/${ORG_PATH} \
-  # Linking the project sources in the GOPATH folder
-  && ln -s /${PROJECT}-sources $GOPATH/src/${REPO_PATH} \
-  && cd $GOPATH/src/${REPO_PATH} \
-  && BUILDINFO_PACKAGE="${ORG_PATH}/${PROJECT}/vendor/${ORG_PATH}/service-status-go/buildinfo." \
-  && VERSION="version=$(git describe --tag --always 2> /dev/null)" \
+ENV ORG_PATH="github.com/Financial-Times"
+ENV SRC_FOLDER="${GOPATH}/src/${ORG_PATH}/${PROJECT}"
+ENV BUILDINFO_PACKAGE="${ORG_PATH}/${PROJECT}/vendor/${ORG_PATH}/service-status-go/buildinfo."
+
+COPY . ${SRC_FOLDER}
+WORKDIR ${SRC_FOLDER}
+
+# Install dependencies
+RUN go get -u github.com/kardianos/govendor \
+    && $GOPATH/bin/govendor sync
+
+# Build app
+RUN VERSION="version=$(git describe --tag --always 2> /dev/null)" \
   && DATETIME="dateTime=$(date -u +%Y%m%d%H%M%S)" \
   && REPOSITORY="repository=$(git config --get remote.origin.url)" \
   && REVISION="revision=$(git rev-parse HEAD)" \
   && BUILDER="builder=$(go version)" \
-  && LDFLAGS="-X '"${BUILDINFO_PACKAGE}$VERSION"' -X '"${BUILDINFO_PACKAGE}$DATETIME"' -X '"${BUILDINFO_PACKAGE}$REPOSITORY"' -X '"${BUILDINFO_PACKAGE}$REVISION"' -X '"${BUILDINFO_PACKAGE}$BUILDER"'" \
-  && echo "Build flags: $LDFLAGS" \
-  && echo "Fetching dependencies..." \
-  && go get -u github.com/kardianos/govendor \
-  && $GOPATH/bin/govendor sync \
-  && go build -ldflags="${LDFLAGS}" \
-  && mv ${PROJECT} /${PROJECT} \
-  && apk del .build-dependencies \
-  && rm -rf $GOPATH /var/cache/apk/*
+  && LDFLAGS="-s -w -X '"${BUILDINFO_PACKAGE}$VERSION"' -X '"${BUILDINFO_PACKAGE}$DATETIME"' -X '"${BUILDINFO_PACKAGE}$REPOSITORY"' -X '"${BUILDINFO_PACKAGE}$REVISION"' -X '"${BUILDINFO_PACKAGE}$BUILDER"'" \
+  && CGO_ENABLED=0 go build -a -o /artifacts/${PROJECT} -ldflags="${LDFLAGS}" \
+  && echo "Build flags: ${LDFLAGS}"
 
+# Multi-stage build - copy certs and the binary into the image
+FROM scratch
 WORKDIR /
+COPY --from=0 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=0 /artifacts/* /
 
 CMD [ "/concept-exporter" ]

--- a/healthcheck.go
+++ b/healthcheck.go
@@ -62,7 +62,7 @@ func (service *healthService) NeoCheck() health.Check {
 	return health.Check{
 		Name:             "CheckConnectivityToNeo4j",
 		BusinessImpact:   "No Business Impact.",
-		PanicGuide:       "https://dewey.ft.com/concept-exporter.html",
+		PanicGuide:       "https://runbooks.in.ft.com/concept-exporter",
 		Severity:         2,
 		TechnicalSummary: fmt.Sprintf("The service is unable to connect to Neo4j (%s). Export won't work because of this", service.config.neoService.NeoURL),
 		Checker: func() (string, error) {
@@ -78,7 +78,7 @@ func (service *healthService) S3WriterCheck() health.Check {
 	return health.Check{
 		Name:             "CheckConnectivityToExportRWS3",
 		BusinessImpact:   "No Business Impact.",
-		PanicGuide:       "https://dewey.ft.com/concept-exporter.html",
+		PanicGuide:       "https://runbooks.in.ft.com/concept-exporter",
 		Severity:         2,
 		TechnicalSummary: "The service is unable to connect to Export-RW-S3. Export won't work because of this",
 		Checker: func() (string, error) {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,256 +3,256 @@
 	"ignore": "test",
 	"package": [
 		{
-			"checksumSHA1": "aXxnxRchBYOultmFLFv1WcZVPRk=",
+			"checksumSHA1": "JRTXOY4qgGJhOh3AveZBgYz7W3A=",
 			"path": "github.com/Financial-Times/annotations-rw-neo4j/annotations",
 			"revision": "9f6ef5ae4ae171e937e24a1468e10492d913a80b",
 			"revisionTime": "2017-09-20T13:12:11Z"
 		},
 		{
-			"checksumSHA1": "pyepZFo4RuuuVXlOIhBmDLufIvI=",
+			"checksumSHA1": "j6lfOuqQgjMm3KP3lq1yUxRDj9k=",
 			"path": "github.com/Financial-Times/api-endpoint",
 			"revision": "802a63542ff0fe6cf81c06a31fdd330a8202ac61",
 			"revisionTime": "2017-07-13T11:12:58Z"
 		},
 		{
-			"checksumSHA1": "511qpj6cfU+pytxOmx4nRWD/QRM=",
+			"checksumSHA1": "JaGW3QqTfF6jXugTnOqQS5YO0k8=",
 			"path": "github.com/Financial-Times/base-ft-rw-app-go/baseftrwapp",
 			"revision": "74eab27b0c6d6044fd326183ddd37ea8ac0e236e",
 			"revisionTime": "2017-10-10T16:23:15Z"
 		},
 		{
-			"checksumSHA1": "lAOCS5ffcJET4YSLKDhvLwgyAF4=",
+			"checksumSHA1": "UN1Fh6p7mi5uUV9o6LdIyglja9Q=",
 			"path": "github.com/Financial-Times/concepts-rw-neo4j/concepts",
 			"revision": "a66a50749e5791b8cd1feebd9268311fbf3da63b",
 			"revisionTime": "2017-10-03T15:43:32Z"
 		},
 		{
-			"checksumSHA1": "QDMeiarH8BGF0s+ndgfvQm6pngM=",
+			"checksumSHA1": "5c+C7+n5iGryLx4fkpd8t7N34iI=",
 			"path": "github.com/Financial-Times/content-rw-neo4j/content",
 			"revision": "641ce08b04170b1253237e1d1a0576b4dc5a12dc",
 			"revisionTime": "2017-10-11T11:59:56Z"
 		},
 		{
-			"checksumSHA1": "9b1y6Aw3eMMToHyNQ4Qx64LYI+U=",
+			"checksumSHA1": "4EOEpxCej+FHfgPz/I7WRiFaQDQ=",
 			"path": "github.com/Financial-Times/financial-instruments-rw-neo4j/financialinstruments",
 			"revision": "fedc405769c84306f44a132075039953a6f7b81f",
 			"revisionTime": "2017-07-25T13:05:33Z"
 		},
 		{
-			"checksumSHA1": "hA3MoSjATaM7AQknoqXcE5skk00=",
+			"checksumSHA1": "fNgRM8ZlaDzdvSpuhSdGxEOrWi4=",
 			"path": "github.com/Financial-Times/go-fthealth/v1_1",
 			"revision": "e7ccca038327a0091303a52445ec1f0fb66cb97b",
 			"revisionTime": "2017-05-25T09:50:41Z"
 		},
 		{
-			"checksumSHA1": "J21jb1gEj3rsMEzfCyDLRStH6yM=",
+			"checksumSHA1": "R32X8CuDAJV1JimomUEh9SFmc8s=",
 			"path": "github.com/Financial-Times/go-logger",
 			"revision": "83fc3e64dc5506fdb4e56b704949d157a121c76c",
 			"revisionTime": "2017-09-14T08:19:45Z"
 		},
 		{
-			"checksumSHA1": "/xshkhtKNzMRlV2Ud9P0QgH+B4g=",
+			"checksumSHA1": "dqF1g4reeLPNN10qTXgDJj3fHm4=",
 			"path": "github.com/Financial-Times/http-handlers-go/httphandlers",
 			"revision": "229ac16f1d9ec9bca485d2dafb9ec14dc7e9ba24",
 			"revisionTime": "2017-08-09T12:10:07Z"
 		},
 		{
-			"checksumSHA1": "G0gakbERWR9IiTLv/7ywoZ7q0OE=",
+			"checksumSHA1": "ZmT6PPQSF7C4aHQ2HO8QsKtYStg=",
 			"path": "github.com/Financial-Times/neo-model-utils-go/mapper",
 			"revision": "1a5407658c842183647f4799bb66ecac73af97a8",
 			"revisionTime": "2017-04-05T08:23:10Z"
 		},
 		{
-			"checksumSHA1": "JkENnWGRaRs//sXtyvgvLdh3k9U=",
+			"checksumSHA1": "ibld3tkf8qmEKpF69JI4mrSN0T8=",
 			"path": "github.com/Financial-Times/neo-utils-go/neoutils",
 			"revision": "5cb1750096545b3c8f7384326247e3e30996a905",
 			"revisionTime": "2017-08-22T15:20:35Z"
 		},
 		{
-			"checksumSHA1": "R788J8zGaFYX6sWRmn4y5wdLcao=",
+			"checksumSHA1": "OViPZtQxGJ8ECf9BBDvQ112tzP4=",
 			"path": "github.com/Financial-Times/organisations-rw-neo4j/organisations",
 			"revision": "1dce3ba256e3a7e3f5cf1c2a9ebd5091daa6e9b8",
 			"revisionTime": "2017-09-01T15:11:45Z"
 		},
 		{
-			"checksumSHA1": "lQfsRf7gWYQDNoI3IOZuwNGUwRo=",
+			"checksumSHA1": "fqpohN7Qp2qj7TLMbUxh/cK4oH0=",
 			"path": "github.com/Financial-Times/service-status-go/buildinfo",
 			"revision": "3f5199736a3d7ae52394c63aac36834786825e21",
 			"revisionTime": "2016-03-23T11:15:42Z"
 		},
 		{
-			"checksumSHA1": "7QAsTdXi/6nTkDhqKy54YIc69d4=",
+			"checksumSHA1": "2rGNLXdRC3qr5n5ll7BpYt8HCK8=",
 			"path": "github.com/Financial-Times/service-status-go/gtg",
 			"revision": "3f5199736a3d7ae52394c63aac36834786825e21",
 			"revisionTime": "2016-03-23T11:15:42Z"
 		},
 		{
-			"checksumSHA1": "YxgjuCI4TJyfQujUeQk3V+gypzo=",
+			"checksumSHA1": "973POGyMCoyaKQuIYX2f7EKFwlQ=",
 			"path": "github.com/Financial-Times/service-status-go/httphandlers",
 			"revision": "3f5199736a3d7ae52394c63aac36834786825e21",
 			"revisionTime": "2016-03-23T11:15:42Z"
 		},
 		{
-			"checksumSHA1": "+Lyl4SYSRLQ7Hz2MNJlGKsmXL+8=",
+			"checksumSHA1": "+sjiZBzrsk91W1A3Md1azCkZadg=",
 			"path": "github.com/Financial-Times/transactionid-utils-go",
 			"revision": "df2f00c734957c9dd651ce23ab0e0902504c7636",
 			"revisionTime": "2017-03-28T16:39:54Z"
 		},
 		{
-			"checksumSHA1": "cQ26ZjI71lDGYOwY9+VprRY4PHI=",
+			"checksumSHA1": "diw1KueSVzsMHPCNDvj+xQiXSTE=",
 			"path": "github.com/Financial-Times/up-rw-app-api-go/rwapi",
 			"revision": "d9d93a1f689538313d12fee6f5f10715cfe280e0",
 			"revisionTime": "2017-07-10T12:58:28Z"
 		},
 		{
-			"checksumSHA1": "guo63XdLn1n7MtawdVcICjFNNBI=",
+			"checksumSHA1": "/6H1rhQmbq8mEP29pnmLmdwBKUE=",
 			"path": "github.com/cyberdelia/go-metrics-graphite",
 			"revision": "39f87cc3b432bbb898d7c643c0e93cac2bc865ad",
 			"revisionTime": "2016-12-19T23:08:53Z"
 		},
 		{
-			"checksumSHA1": "DuEyF75v9xaKXfJsCPRdHNOpGZk=",
+			"checksumSHA1": "OFu4xJEIjiI8Suu+j/gabfp+y6Q=",
 			"origin": "github.com/stretchr/testify/vendor/github.com/davecgh/go-spew/spew",
 			"path": "github.com/davecgh/go-spew/spew",
 			"revision": "890a5c3458b43e6104ff5da8dfa139d013d77544",
 			"revisionTime": "2017-07-05T02:17:15Z"
 		},
 		{
-			"checksumSHA1": "IkPM2QLv9urri7S49wzroQx9oXA=",
+			"checksumSHA1": "g/V4qrXjUGG9B+e3hB+4NAYJ5Gs=",
 			"path": "github.com/gorilla/context",
 			"revision": "08b5f424b9271eedf6f9f0ce86cb9396ed337a42",
 			"revisionTime": "2016-08-17T18:46:32Z"
 		},
 		{
-			"checksumSHA1": "4OqsCtUfKO1c0KlmlgS4JBt3g4E=",
+			"checksumSHA1": "/lWfaq/Ok+El1amGaf3wPY5JpUc=",
 			"path": "github.com/gorilla/handlers",
 			"revision": "a4d79d4487c2430a17d9dc8a1f74d1a6ed6908ca",
 			"revisionTime": "2017-06-02T15:16:48Z"
 		},
 		{
-			"checksumSHA1": "V3fAepHCumzqiy8JK4fI4iVp9jo=",
+			"checksumSHA1": "06I0wBTXKCu2Br46zNqsv+LXRgY=",
 			"path": "github.com/gorilla/mux",
 			"revision": "7625a85c14e615274a4ee4bc8654f72310a563e4",
 			"revisionTime": "2017-10-20T03:47:00Z"
 		},
 		{
-			"checksumSHA1": "KJqRW8jfPoHquMAd6FI7x92JxFs=",
+			"checksumSHA1": "tUGxc7rfX0cmhOOUDhMuAZ9rWsA=",
 			"path": "github.com/hashicorp/go-version",
 			"revision": "fc61389e27c71d120f87031ca8c88a3428f372dd",
 			"revisionTime": "2017-09-14T15:41:28Z"
 		},
 		{
-			"checksumSHA1": "vs2D6S319JTqmlSB1UonoX8+3yE=",
+			"checksumSHA1": "93y+QUClruOxWiD2VjG2mGjYopg=",
 			"path": "github.com/jawher/mow.cli",
 			"revision": "08e2d552570d9de701d48914672398b1551ccaf1",
 			"revisionTime": "2017-10-25T11:39:33Z"
 		},
 		{
-			"checksumSHA1": "gVGl3skHHlqE+JFBqC7Vs6phjpg=",
+			"checksumSHA1": "nMm7xgpbpYYWy/zdKttNSoo1HAE=",
 			"path": "github.com/jmcvetta/neoism",
 			"revision": "4674154f870d19b356581843f481dccd6792dcc0",
 			"revisionTime": "2017-03-06T10:41:37Z"
 		},
 		{
-			"checksumSHA1": "QD46tPMRlsF6qRy3lUmC0ZCCo1A=",
+			"checksumSHA1": "khL6oKjx81rAZKW+36050b7f5As=",
 			"path": "github.com/jmcvetta/randutil",
 			"revision": "2bb1b664bcff821e02b2a0644cd29c7e824d54f8",
 			"revisionTime": "2015-08-17T12:26:01Z"
 		},
 		{
-			"checksumSHA1": "ZbvybRLthm+bve1duASQ5ghFl6Y=",
+			"checksumSHA1": "eOXF2PEvYLMeD8DSzLZJWbjYzco=",
 			"path": "github.com/kr/pretty",
 			"revision": "cfb55aafdaf3ec08f0db22699ab822c50091b1c4",
 			"revisionTime": "2016-08-23T17:07:15Z"
 		},
 		{
-			"checksumSHA1": "OdjJhBQQtNpITIPc6X+C9e/6RLw=",
+			"checksumSHA1": "uulQHQ7IsRKqDudBC8Go9J0gtAc=",
 			"path": "github.com/kr/text",
 			"revision": "7cafcd837844e784b526369c9bce262804aebc60",
 			"revisionTime": "2016-05-04T02:26:26Z"
 		},
 		{
-			"checksumSHA1": "eVoyhpCbyPg6D3P63EStHNO6iIQ=",
+			"checksumSHA1": "Se195FlZ160eaEk/uVx4KdTPSxU=",
 			"path": "github.com/pborman/uuid",
 			"revision": "e790cca94e6cc75c7064b1332e63811d4aae1a53",
 			"revisionTime": "2017-06-12T15:36:48Z"
 		},
 		{
-			"checksumSHA1": "mR79ABWFyrDTTdhFPxwUN19T45Q=",
+			"checksumSHA1": "rJab1YdNhQooDiBWNnt7TLWPyBU=",
 			"path": "github.com/pkg/errors",
 			"revision": "f15c970de5b76fac0b59abb32d62c17cc7bed265",
 			"revisionTime": "2017-10-18T19:55:50Z"
 		},
 		{
-			"checksumSHA1": "+oyIJwPyeof36XCkY8awrNfxaNM=",
+			"checksumSHA1": "zKKp5SZ3d3ycKe4EKMNT0BqAWBw=",
 			"origin": "github.com/stretchr/testify/vendor/github.com/pmezard/go-difflib/difflib",
 			"path": "github.com/pmezard/go-difflib/difflib",
 			"revision": "890a5c3458b43e6104ff5da8dfa139d013d77544",
 			"revisionTime": "2017-07-05T02:17:15Z"
 		},
 		{
-			"checksumSHA1": "DIjooF5+DLH5JSOjqnBlfNh9dFU=",
+			"checksumSHA1": "KAzbLjI9MzW2tjfcAsK75lVRp6I=",
 			"path": "github.com/rcrowley/go-metrics",
 			"revision": "1f30fe9094a513ce4c700b9a54458bbb0c96996c",
 			"revisionTime": "2016-11-28T21:05:44Z"
 		},
 		{
-			"checksumSHA1": "uob8uFli8j89vR2fM+8OPNpW4Y4=",
+			"checksumSHA1": "8Lm8nsMCFz4+gr9EvQLqK8+w+Ks=",
 			"path": "github.com/sethgrid/pester",
 			"revision": "8053687f99650573b28fb75cddf3f295082704d7",
 			"revisionTime": "2016-04-29T17:20:22Z"
 		},
 		{
-			"checksumSHA1": "t5W90J4d7vhrs6+LDp0BalvCZEU=",
+			"checksumSHA1": "BYvROBsiyAXK4sq6yhDe8RgT4LM=",
 			"path": "github.com/sirupsen/logrus",
 			"revision": "89742aefa4b206dcf400792f3bd35b542998eb3b",
 			"revisionTime": "2017-08-22T13:27:46Z"
 		},
 		{
-			"checksumSHA1": "bEYPw3QRqpj0ID7Q2FAr0xnF1Xw=",
+			"checksumSHA1": "Kt+BhrXMyYvOc9TGiBVOSNn6wcc=",
 			"path": "github.com/sirupsen/logrus/hooks/test",
 			"revision": "89742aefa4b206dcf400792f3bd35b542998eb3b",
 			"revisionTime": "2017-08-22T13:27:46Z"
 		},
 		{
-			"checksumSHA1": "gk/LQDNi6u6FONxvvt7JRdiTVas=",
+			"checksumSHA1": "jvP3O/wTF9QNi6amOjOzssnzvgA=",
 			"path": "github.com/spaolacci/murmur3",
 			"revision": "4ec5a0f56d4fc178129a8433576bf6f2fe672a9e",
 			"revisionTime": "2017-08-06T11:57:23Z"
 		},
 		{
-			"checksumSHA1": "iDI3Ec9Co5dn9MAf6VRg5cGNRPI=",
+			"checksumSHA1": "EO+jcRet/AJ6IY3lBO8l8BLsZWg=",
 			"origin": "github.com/stretchr/testify/vendor/github.com/stretchr/objx",
 			"path": "github.com/stretchr/objx",
 			"revision": "890a5c3458b43e6104ff5da8dfa139d013d77544",
 			"revisionTime": "2017-07-05T02:17:15Z"
 		},
 		{
-			"checksumSHA1": "5YCFabYzA1Zv/nGy35VDX5WBP4E=",
+			"checksumSHA1": "mGbTYZ8dHVTiPTTJu3ktp+84pPI=",
 			"path": "github.com/stretchr/testify/assert",
 			"revision": "890a5c3458b43e6104ff5da8dfa139d013d77544",
 			"revisionTime": "2017-07-05T02:17:15Z"
 		},
 		{
-			"checksumSHA1": "q+MPhXUlpfmP5UgmOySPeldXwvs=",
+			"checksumSHA1": "o+jsS/rxceTym4M3reSPfrPxaio=",
 			"path": "github.com/stretchr/testify/mock",
 			"revision": "890a5c3458b43e6104ff5da8dfa139d013d77544",
 			"revisionTime": "2017-07-05T02:17:15Z"
 		},
 		{
-			"checksumSHA1": "svOZfLx/kztaEcG9IdvrQsZNdsY=",
+			"checksumSHA1": "7vs6dSc1PPGBKyzb/SCIyeMJPLQ=",
 			"path": "github.com/stretchr/testify/require",
 			"revision": "890a5c3458b43e6104ff5da8dfa139d013d77544",
 			"revisionTime": "2017-07-05T02:17:15Z"
 		},
 		{
-			"checksumSHA1": "kZScNEQ20idmssR5L8ynNj0Gsts=",
+			"checksumSHA1": "9Zw986fuQM/hCoVd8vmHoSM+8sU=",
 			"path": "github.com/ugorji/go/codec",
 			"revision": "5efa3251c7f7d05e5d9704a69a984ec9f1386a40",
 			"revisionTime": "2017-06-20T10:48:52Z"
 		},
 		{
-			"checksumSHA1": "jzagU1HfylQH/eBE9u9MrpkVHw8=",
+			"checksumSHA1": "dBmk68coq8umF51FL23vNXOOS7o=",
 			"path": "go4.org/osutil",
 			"revision": "034d17a462f7b2dcd1a4a73553ec5357ff6e6c6e",
 			"revisionTime": "2017-05-24T23:16:39Z"
@@ -270,7 +270,7 @@
 			"revisionTime": "2017-10-17T20:25:22Z"
 		},
 		{
-			"checksumSHA1": "6ws9uckd33muPlD8IRR8IsNGfA0=",
+			"checksumSHA1": "fGI0otWWIlwqEhJDgXdhdLlUJzM=",
 			"path": "golang.org/x/sys/unix",
 			"revision": "95c6576299259db960f6c5b9b69ea52422860fce",
 			"revisionTime": "2017-10-30T10:08:44Z"
@@ -282,13 +282,13 @@
 			"revisionTime": "2017-10-30T10:08:44Z"
 		},
 		{
-			"checksumSHA1": "o6bET16IF+7+f1w7B/JNyIIYzak=",
+			"checksumSHA1": "k3L1Q7anlDsX2njPAE5Dd2SWVlw=",
 			"path": "gopkg.in/jmcvetta/napping.v3",
 			"revision": "4c7b4b235c63152afa9a1c6384e708e0fbfd77ca",
 			"revisionTime": "2017-03-11T05:32:04Z"
 		},
 		{
-			"checksumSHA1": "aUDnhyGTHeiMERx4L4jx/zLsvSQ=",
+			"checksumSHA1": "RDJpJQwkF012L6m/2BJizyOksNw=",
 			"path": "gopkg.in/yaml.v2",
 			"revision": "eb3733d160e74a9c7e442f435eb3bea458e1d19f",
 			"revisionTime": "2017-08-12T16:00:11Z"


### PR DESCRIPTION
Updating the docker image due to GO Security Vulnerability:
- For the Go-based services, we are migrating all of our Docker files to multi-stage builds (if not in place already) using `golang:1` as a base image and `scratch` for the runtime.
- The same `golang:1` is used for CircleCI image.