### PR TITLE
UPPSF-549 Hide broken concepts

### DIFF
--- a/concept/s3_writer.go
+++ b/concept/s3_writer.go
@@ -62,7 +62,7 @@ func (u *S3Updater) CheckHealth(client Client) (string, error) {
 		return "Error in getting request to check if S3 Writer is good to go.", err
 	}
 	defer func() {
-		io.Copy(ioutil.Discard, resp.Body)
+		_, _ = io.Copy(ioutil.Discard, resp.Body)
 		resp.Body.Close()
 	}()
 	if resp.StatusCode != http.StatusOK {

--- a/db/fixtures/Annotations-a435b4ec-b207-4dce-ac0a-f8e7bbef310b-person.json
+++ b/db/fixtures/Annotations-a435b4ec-b207-4dce-ac0a-f8e7bbef310b-person.json
@@ -1,0 +1,28 @@
+[
+  {
+    "thing": {
+      "id": "http://api.ft.com/things/b2fa511e-a031-4d52-b37d-72fd290b39ce",
+      "prefLabel": "Peter Foster",
+      "types": [
+        "Thing",
+        "Concept",
+        "Person"
+      ],
+      "predicate": "hasAuthor"
+    },
+    "provenances": [
+      {
+        "scores": [
+          {
+            "scoringSystem": "http://api.ft.com/scoringsystem/FT-RELEVANCE-SYSTEM",
+            "value": 1
+          },
+          {
+            "scoringSystem": "http://api.ft.com/scoringsystem/FT-CONFIDENCE-SYSTEM",
+            "value": 1
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/db/fixtures/Person-b2fa511e-a031-4d52-b37d-72fd290b39ce.json
+++ b/db/fixtures/Person-b2fa511e-a031-4d52-b37d-72fd290b39ce.json
@@ -1,0 +1,24 @@
+{
+  "prefUUID": "b2fa511e-a031-4d52-b37d-72fd290b39ce",
+  "prefLabel": "Peter Foster",
+  "type": "Person",
+  "aliases": [
+    "Peter Foster"
+  ],
+  "emailAddress": "peter.foster@ft.com",
+  "twitterHandle": "@pmdfoster",
+  "sourceRepresentations": [
+    {
+      "uuid": "b2fa511e-a031-4d52-b37d-72fd290b39ce",
+      "type": "Person",
+      "prefLabel": "Peter Foster",
+      "authority": "Smartlogic",
+      "authorityValue": "b2fa511e-a031-4d52-b37d-72fd290b39ce",
+      "aliases": [
+        "Peter Foster"
+      ],
+      "emailAddress": "peter.foster@ft.com",
+      "twitterHandle": "@pmdfoster"
+    }
+  ]
+}

--- a/db/neo4j.go
+++ b/db/neo4j.go
@@ -39,28 +39,25 @@ type Concept struct {
 func (s *NeoService) Read(conceptType string, conceptCh chan Concept) (int, bool, error) {
 	results := []Concept{}
 	stmt := fmt.Sprintf(`
-			MATCH (c:%s)-[:MENTIONS|MAJOR_MENTIONS|ABOUT|IS_CLASSIFIED_BY|IS_PRIMARILY_CLASSIFIED_BY|HAS_AUTHOR|HAS_BRAND]-(cc:Content)
-			MATCH (c)-[:EQUIVALENT_TO]->(x:Thing)
-			RETURN DISTINCT x.prefUUID AS Uuid, x.prefLabel AS PrefLabel, labels(c) AS Labels
+		MATCH (c:%s)-[:MENTIONS|MAJOR_MENTIONS|ABOUT|IS_CLASSIFIED_BY|IS_PRIMARILY_CLASSIFIED_BY|HAS_AUTHOR|HAS_BRAND]-(cc:Content)
+		MATCH (c)-[:EQUIVALENT_TO]->(x:Thing)
+		RETURN DISTINCT x.prefUUID AS Uuid, x.prefLabel AS PrefLabel, labels(x) AS Labels
 		`, conceptType)
 
 	if conceptType == "Organisation" {
 		stmt = `
-		MATCH (content:Content)-[rel:MENTIONS|MAJOR_MENTIONS|ABOUT|IS_CLASSIFIED_BY|IS_PRIMARILY_CLASSIFIED_BY|HAS_AUTHOR]->(concept:Organisation)
-		OPTIONAL MATCH (concept)-[:EQUIVALENT_TO]->(x:Thing)
-		OPTIONAL MATCH (concept)<-[:IDENTIFIES]-(factset:FactsetIdentifier)
-		OPTIONAL MATCH (concept)<-[:IDENTIFIES]-(lei:LegalEntityIdentifier)
-		OPTIONAL MATCH (concept)<-[:ISSUED_BY]-(:FinancialInstrument)<-[:IDENTIFIES]-(figi:FIGIIdentifier)
-		RETURN DISTINCT coalesce(x.prefUUID, concept.uuid) as Uuid, coalesce(labels(x), labels(concept)) as Labels,
-                coalesce(x.prefLabel, concept.prefLabel) as PrefLabel, coalesce(x.factsetId,factset.value) as factsetId, coalesce(x.leiCode, lei.value) as leiCode, coalesce(x.figiCode, figi.value) as FIGI
+		MATCH (content:Content)-[:MENTIONS|MAJOR_MENTIONS|ABOUT|IS_CLASSIFIED_BY|IS_PRIMARILY_CLASSIFIED_BY|HAS_AUTHOR]->(:Organisation)-[:EQUIVALENT_TO]->(x:Thing)
+		MATCH (x:Thing)<-[:EQUIVALENT_TO]-(concept)
+		OPTIONAL MATCH (concept)<-[:ISSUED_BY]-(fi:FinancialInstrument)
+		RETURN DISTINCT x.prefUUID AS Uuid, labels(x) AS Labels, x.prefLabel AS PrefLabel,
+			CASE concept.authority WHEN 'FACTSET' THEN concept.authorityValue END AS factsetId,
+			x.leiCode AS leiCode, fi.figiCode AS FIGI
 		`
 	}
 	if conceptType == "Person" {
 		stmt = `
-		MATCH (content:Content)-[rel:MENTIONS|MAJOR_MENTIONS|ABOUT|IS_CLASSIFIED_BY|IS_PRIMARILY_CLASSIFIED_BY|HAS_AUTHOR]->(concept:Person)
-		OPTIONAL MATCH (concept)-[:EQUIVALENT_TO]->(x:Thing)
-		RETURN DISTINCT coalesce(x.prefUUID, concept.uuid) as Uuid, coalesce(labels(x), labels(concept)) as Labels,
-                coalesce(x.prefLabel, concept.prefLabel) as PrefLabel
+		MATCH (content:Content)-[:MENTIONS|MAJOR_MENTIONS|ABOUT|IS_CLASSIFIED_BY|IS_PRIMARILY_CLASSIFIED_BY|HAS_AUTHOR]->(:Person)-[:EQUIVALENT_TO]->(x:Thing)
+		RETURN DISTINCT x.prefUUID as Uuid, x.prefLabel as PrefLabel, labels(x) as Labels
 		`
 	}
 

--- a/db/neo4j_integration_test.go
+++ b/db/neo4j_integration_test.go
@@ -35,7 +35,6 @@ const (
 var allUUIDs = []string{contentUUID, brandParentUUID, brandChildUUID, brandGrandChildUUID, financialInstrumentUUID, companyUUID, organisationUUID}
 
 func getDatabaseConnection(t *testing.T) neoutils.NeoConnection {
-	l := logger.NewUPPLogger("test-concept-exporter", "PANIC")
 	if testing.Short() {
 		t.Skip("Neo4j integration for long tests only.")
 	}
@@ -46,7 +45,7 @@ func getDatabaseConnection(t *testing.T) neoutils.NeoConnection {
 
 	conf := neoutils.DefaultConnectionConfig()
 	conf.Transactional = false
-	conn, err := neoutils.Connect(url, conf, l)
+	conn, err := neoutils.Connect(url, conf, logger.NewUPPLogger("test-concept-exporter", "PANIC"))
 	assert.NoError(t, err, "Failed to connect to Neo4j")
 	return conn
 }

--- a/export/worker.go
+++ b/export/worker.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 
 	"github.com/Financial-Times/concept-exporter/concept"
-	"github.com/Financial-Times/go-logger/v2"
+	logger "github.com/Financial-Times/go-logger/v2"
 	"github.com/pborman/uuid"
 )
 
@@ -184,7 +184,10 @@ func (fe *FullExporter) runExport(worker *concept.Worker, tid string) {
 				return
 			}
 			fe.incWorkerProgress(worker)
-			fe.Exporter.Write(c, worker.ConceptType, tid)
+			err := fe.Exporter.Write(c, worker.ConceptType, tid)
+			if err != nil {
+				fe.Log.WithTransactionID(tid).WithError(err).Warn("CSV exporter writing failed")
+			}
 		case err, ok := <-worker.Errch:
 			if !ok {
 				//channel closed

--- a/web/resources.go
+++ b/web/resources.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/Financial-Times/concept-exporter/export"
-	"github.com/Financial-Times/go-logger/v2"
+	logger "github.com/Financial-Times/go-logger/v2"
 	transactionidutils "github.com/Financial-Times/transactionid-utils-go"
 )
 
@@ -70,7 +70,7 @@ func (handler *RequestHandler) Export(writer http.ResponseWriter, request *http.
 
 func (handler *RequestHandler) getCandidateConceptTypes(request *http.Request, tid string) (candidates []string, errMsg string) {
 	candidates = extractCandidateConceptTypesFromRequest(request, handler.Log.WithTransactionID(tid))
-	if candidates != nil && len(candidates) != 0 {
+	if len(candidates) != 0 {
 		var unsupported []string
 		for i, cand := range candidates {
 			found := false
@@ -92,7 +92,7 @@ func (handler *RequestHandler) getCandidateConceptTypes(request *http.Request, t
 			return
 		}
 	}
-	if candidates == nil || len(candidates) == 0 {
+	if len(candidates) == 0 {
 		handler.Log.WithTransactionID(tid).Infof("Content type candidates are empty. Using all supported ones: %v", handler.ConceptTypes)
 		candidates = handler.ConceptTypes
 	}


### PR DESCRIPTION
Do not add broken concepts without canonical node to the export.
Rewrite to not use Identifier nodes in the queries.