### PR TITLE
UPPSF-549 Fix cypher queries

### DIFF
--- a/db/fixtures/Annotations-a435b4ec-b207-4dce-ac0a-f8e7bbef310b-person-with-brand.json
+++ b/db/fixtures/Annotations-a435b4ec-b207-4dce-ac0a-f8e7bbef310b-person-with-brand.json
@@ -1,0 +1,28 @@
+[
+  {
+    "thing": {
+      "id": "http://api.ft.com/things/a7b4786c-aae9-3e3e-93a0-2c82a6383534",
+      "prefLabel": "Jancis Robinson",
+      "types": [
+        "Thing",
+        "Concept",
+        "Person"
+      ],
+      "predicate": "hasAuthor"
+    },
+    "provenances": [
+      {
+        "scores": [
+          {
+            "scoringSystem": "http://api.ft.com/scoringsystem/FT-RELEVANCE-SYSTEM",
+            "value": 1
+          },
+          {
+            "scoringSystem": "http://api.ft.com/scoringsystem/FT-CONFIDENCE-SYSTEM",
+            "value": 1
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/db/fixtures/Organisation-Fakebook-eac853f5-3859-4c08-8540-55e043719400-Factset.json
+++ b/db/fixtures/Organisation-Fakebook-eac853f5-3859-4c08-8540-55e043719400-Factset.json
@@ -1,0 +1,43 @@
+{
+    "prefUUID": "eac853f5-3859-4c08-8540-55e043719400",
+    "prefLabel": "Fakebook",
+    "type": "PublicCompany",
+    "aliases": [
+        "Fakebook Inc"
+    ],
+    "aggregateHash": "7906209953307351514",
+    "sourceRepresentations": [
+        {
+            "uuid": "eac853f5-3859-4c08-8540-55e043719400",
+            "prefLabel": "Fakebook",
+            "type": "Organisation",
+            "authority": "Smartlogic",
+            "authorityValue": "eac853f5-3859-4c08-8540-55e043719400"
+        },
+        {
+            "uuid": "eac853f5-3859-4c08-8540-55e043719401",
+            "prefLabel": "Fakebook",
+            "type": "Organisation",
+            "authority": "FACTSET",
+            "authorityValue": "FACTSET1"
+        }
+    ],
+    "alternativeIdentifiers": {
+        "uuids": [
+            "eac853f5-3859-4c08-8540-55e043719400"
+        ],
+        "leiCode": "BQ4BKCS1HXDV9TTTTTTTT"
+    },
+    "properName": "Fakebook & Co.",
+    "shortName": "Fakebook",
+    "tradeNames": [
+        "Fakebook"
+    ],
+    "countryCode": "US",
+    "countryOfRisk": "US",
+    "countryOfIncorporation": "US",
+    "countryOfOperations": "US",
+    "postalCode": "94104",
+    "yearFounded": 1852,
+    "leiCode": "PBLD0EJDB5FWOLXP3B76"
+}

--- a/db/fixtures/Organisation-Fakebook-eac853f5-3859-4c08-8540-55e043719400-Factset2.json
+++ b/db/fixtures/Organisation-Fakebook-eac853f5-3859-4c08-8540-55e043719400-Factset2.json
@@ -1,0 +1,50 @@
+{
+    "prefUUID": "eac853f5-3859-4c08-8540-55e043719400",
+    "prefLabel": "Fakebook",
+    "type": "PublicCompany",
+    "aliases": [
+        "Fakebook Inc"
+    ],
+    "aggregateHash": "7906209953307351514",
+    "sourceRepresentations": [
+        {
+            "uuid": "eac853f5-3859-4c08-8540-55e043719400",
+            "prefLabel": "Fakebook",
+            "type": "Organisation",
+            "authority": "Smartlogic",
+            "authorityValue": "eac853f5-3859-4c08-8540-55e043719400"
+        },
+        {
+            "uuid": "eac853f5-3859-4c08-8540-55e043719401",
+            "prefLabel": "Fakebook",
+            "type": "Organisation",
+            "authority": "FACTSET",
+            "authorityValue": "FACTSET1"
+        },
+        {
+            "uuid": "eac853f5-3859-4c08-8540-55e043719402",
+            "prefLabel": "Fakebook",
+            "type": "Organisation",
+            "authority": "FACTSET",
+            "authorityValue": "FACTSET2"
+        }
+    ],
+    "alternativeIdentifiers": {
+        "uuids": [
+            "eac853f5-3859-4c08-8540-55e043719400"
+        ],
+        "leiCode": "BQ4BKCS1HXDV9TTTTTTTT"
+    },
+    "properName": "Fakebook & Co.",
+    "shortName": "Fakebook",
+    "tradeNames": [
+        "Fakebook"
+    ],
+    "countryCode": "US",
+    "countryOfRisk": "US",
+    "countryOfIncorporation": "US",
+    "countryOfOperations": "US",
+    "postalCode": "94104",
+    "yearFounded": 1852,
+    "leiCode": "PBLD0EJDB5FWOLXP3B76"
+}

--- a/db/fixtures/Person-9070a3f1-aa6d-48a7-9d97-f56a47513cef-With-Brand.json
+++ b/db/fixtures/Person-9070a3f1-aa6d-48a7-9d97-f56a47513cef-With-Brand.json
@@ -1,0 +1,56 @@
+{
+  "prefUUID": "9070a3f1-aa6d-48a7-9d97-f56a47513cef",
+  "prefLabel": "Jancis Robinson",
+  "type": "Person",
+  "aliases": [
+    "Jancis Mary Robinson",
+    "Jancis Robinson"
+  ],
+  "parentUUIDs": [
+    "dbb0bdae-1f0c-11e4-b0cb-b2227cce2b54"
+  ],
+  "descriptionXML": "<p>Jancis Robinson has been writing and broadcasting about wine since 1975, and has been the FT’s wine correspondent since 1989. Her principal occupation nowadays is www.jancisrobinson.com but she is also responsible for many of the standard reference books on wine including The Oxford Companion to Wine and, with Hugh Johnson, The World Atlas of Wine.</p>\n<p>She qualified as a Master of Wine, the first from outside the wine trade, in 1984, and regularly judges and lectures about wine around the world. She has presented several award-winning television programmes including Jancis Robinson’s Wine Course and Vintners’ Tales, and is a professional narrator.</p>",
+  "_imageUrl": "https://www.ft.com/__origami/service/image/v2/images/raw/fthead-v1:jancis-robinson?source=next",
+  "emailAddress": "jancis@jancisrobinson.com",
+  "twitterHandle": "@JancisRobinson",
+  "scopeNote": "Wine Columnist",
+  "sourceRepresentations": [
+    {
+      "uuid": "22a60434-a9d5-3a38-a337-fdd904e99f6f",
+      "type": "Person",
+      "prefLabel": "Jancis Robinson",
+      "authority": "Wikidata",
+      "authorityValue": "http://www.wikidata.org/entity/Q463895",
+      "scopeNote": "British journalist"
+    },
+    {
+      "uuid": "a7b4786c-aae9-3e3e-93a0-2c82a6383534",
+      "type": "Brand",
+      "prefLabel": "Jancis Robinson",
+      "authority": "TME",
+      "authorityValue": "QnJhbmRzXzgx-QnJhbmRz",
+      "aliases": [
+        "Jancis Robinson"
+      ],
+      "parentUUIDs": [
+        "dbb0bdae-1f0c-11e4-b0cb-b2227cce2b54"
+      ],
+      "isDeprecated": true
+    },
+    {
+      "uuid": "9070a3f1-aa6d-48a7-9d97-f56a47513cef",
+      "type": "Person",
+      "prefLabel": "Jancis Robinson",
+      "authority": "Smartlogic",
+      "authorityValue": "9070a3f1-aa6d-48a7-9d97-f56a47513cef",
+      "aliases": [
+        "Jancis Robinson"
+      ],
+      "descriptionXML": "<p>Jancis Robinson has been writing and broadcasting about wine since 1975, and has been the FT’s wine correspondent since 1989. Her principal occupation nowadays is www.jancisrobinson.com but she is also responsible for many of the standard reference books on wine including The Oxford Companion to Wine and, with Hugh Johnson, The World Atlas of Wine.</p>\n<p>She qualified as a Master of Wine, the first from outside the wine trade, in 1984, and regularly judges and lectures about wine around the world. She has presented several award-winning television programmes including Jancis Robinson’s Wine Course and Vintners’ Tales, and is a professional narrator.</p>",
+      "_imageUrl": "https://www.ft.com/__origami/service/image/v2/images/raw/fthead-v1:jancis-robinson?source=next",
+      "emailAddress": "jancis@jancisrobinson.com",
+      "twitterHandle": "@JancisRobinson",
+      "scopeNote": "Wine Columnist"
+    }
+  ]
+}

--- a/db/neo4j.go
+++ b/db/neo4j.go
@@ -39,8 +39,8 @@ type Concept struct {
 func (s *NeoService) Read(conceptType string, conceptCh chan Concept) (int, bool, error) {
 	results := []Concept{}
 	stmt := fmt.Sprintf(`
-		MATCH (c:%s)-[:MENTIONS|MAJOR_MENTIONS|ABOUT|IS_CLASSIFIED_BY|IS_PRIMARILY_CLASSIFIED_BY|HAS_AUTHOR|HAS_BRAND]-(cc:Content)
-		MATCH (c)-[:EQUIVALENT_TO]->(x:Thing)
+		MATCH (x:%s)<-[:EQUIVALENT_TO]-(:Concept)<-[:MENTIONS|MAJOR_MENTIONS|ABOUT|IS_CLASSIFIED_BY|IS_PRIMARILY_CLASSIFIED_BY|HAS_AUTHOR|HAS_BRAND]-(:Content)
+		USING SCAN x:%[1]s
 		RETURN DISTINCT x.prefUUID AS Uuid, x.prefLabel AS PrefLabel, labels(x) AS Labels
 		`, conceptType)
 
@@ -56,7 +56,8 @@ func (s *NeoService) Read(conceptType string, conceptCh chan Concept) (int, bool
 	}
 	if conceptType == "Person" {
 		stmt = `
-		MATCH (content:Content)-[:MENTIONS|MAJOR_MENTIONS|ABOUT|IS_CLASSIFIED_BY|IS_PRIMARILY_CLASSIFIED_BY|HAS_AUTHOR]->(:Person)-[:EQUIVALENT_TO]->(x:Thing)
+		MATCH (:Content)-[:MENTIONS|MAJOR_MENTIONS|ABOUT|IS_CLASSIFIED_BY|IS_PRIMARILY_CLASSIFIED_BY|HAS_AUTHOR]->(:Concept)-[:EQUIVALENT_TO]->(x:Person)
+		USING SCAN x:Person
 		RETURN DISTINCT x.prefUUID as Uuid, x.prefLabel as PrefLabel, labels(x) as Labels
 		`
 	}

--- a/db/neo4j.go
+++ b/db/neo4j.go
@@ -46,12 +46,16 @@ func (s *NeoService) Read(conceptType string, conceptCh chan Concept) (int, bool
 
 	if conceptType == "Organisation" {
 		stmt = `
-		MATCH (content:Content)-[:MENTIONS|MAJOR_MENTIONS|ABOUT|IS_CLASSIFIED_BY|IS_PRIMARILY_CLASSIFIED_BY|HAS_AUTHOR]->(:Organisation)-[:EQUIVALENT_TO]->(x:Thing)
-		MATCH (x:Thing)<-[:EQUIVALENT_TO]-(concept)
+		MATCH (:Content)-[:MENTIONS|MAJOR_MENTIONS|ABOUT|IS_CLASSIFIED_BY|IS_PRIMARILY_CLASSIFIED_BY|HAS_AUTHOR]->()-[:EQUIVALENT_TO]->(x:Organisation)
+		USING SCAN x:Organisation
+		WITH DISTINCT x
+		MATCH (x)<-[:EQUIVALENT_TO]-(concept)
 		OPTIONAL MATCH (concept)<-[:ISSUED_BY]-(fi:FinancialInstrument)
-		RETURN DISTINCT x.prefUUID AS Uuid, labels(x) AS Labels, x.prefLabel AS PrefLabel,
-			CASE concept.authority WHEN 'FACTSET' THEN concept.authorityValue END AS factsetId,
-			x.leiCode AS leiCode, fi.figiCode AS FIGI
+		WITH x, collect(DISTINCT CASE concept.authority WHEN 'FACTSET' THEN concept.authorityValue END) AS factsetIds,
+			collect(DISTINCT fi.figiCode) as figiCodes 
+		RETURN x.prefUUID AS Uuid, labels(x) AS Labels, x.prefLabel AS PrefLabel, x.leiCode AS leiCode,
+			reduce(s=head(factsetIds), n IN tail(factsetIds) | s + ';' + n) AS factsetId,
+			reduce(s=head(figiCodes), n IN tail(figiCodes) | s + ';' + n) AS FIGI
 		`
 	}
 	if conceptType == "Person" {


### PR DESCRIPTION
This PR fixes two issues:
1. People were returned in the Brand export
2. For organisation export when there are no annotations on the Factset source node no Factset ID was returned

Handling for more than one Factset/FIGI is added for future proofing (currently there are no such concepts) by joining the multiple IDs with ';'. This is done to not break the current output format.