### PR TITLE
Export industry classifications

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,5 @@
 # This repo is owned by the universal-publishing team, which is  administered by the FT Content Programme Team.
 * @Financial-Times/universal-publishing
+
+# This repo is supported by:
+* @Financial-Times/metadata-team

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -1,0 +1,17 @@
+FROM golang:1
+
+ENV PROJECT=concept-exporter
+WORKDIR /${PROJECT}
+
+RUN echo "Fetching dependencies..." \
+    && git clone https://github.com/vishnubob/wait-for-it.git \
+    && cd wait-for-it \
+    && mv ./wait-for-it.sh /${PROJECT}
+
+COPY go.mod /
+COPY go.sum /
+RUN go mod download
+
+COPY . .
+
+ENTRYPOINT ["./wait-for-it.sh", "neo4j:7474", "-t", "60", "--"]

--- a/README.md
+++ b/README.md
@@ -18,13 +18,12 @@ There are 2 types of exports:
         go test -v -race ./...
         go install
 
-2. Run the integration tests:
-        
-        go test -tags=integration -race ./...
-  
-You should have a running local instance of Neo4j:
-
-        docker run --rm -p 7474:7474 -p 7687:7687 -e NEO4J_ACCEPT_LICENSE_AGREEMENT="yes" -e NEO4J_AUTH="none" neo4j:3.4.10-enterprise
+2. Run unit and integration tests:
+    ```
+    docker-compose -f docker-compose-tests.yml up -d --build && \
+    docker logs -f test-runner && \
+    docker-compose -f docker-compose-tests.yml down -v
+    ```
 
 3. Run the binary (using the `help` flag to see the available optional arguments):
 

--- a/db/fixtures/NAICS-Industry-Classification-38ee195d-ebdd-48a9-af4b-c8a322e7b04d.json
+++ b/db/fixtures/NAICS-Industry-Classification-38ee195d-ebdd-48a9-af4b-c8a322e7b04d.json
@@ -1,0 +1,22 @@
+{
+  "prefUUID": "38ee195d-ebdd-48a9-af4b-c8a322e7b04d",
+  "prefLabel": "Another Internet Publishing and Broadcasting and Web Search Portals",
+  "type": "NAICSIndustryClassification",
+  "aliases": [
+    "Another Internet Publishing and Broadcasting and Web Search Portals"
+  ],
+  "industryIdentifier": "519131",
+  "sourceRepresentations": [
+    {
+      "uuid": "38ee195d-ebdd-48a9-af4b-c8a322e7b04d",
+      "type": "NAICSIndustryClassification",
+      "prefLabel": "Another Internet Publishing and Broadcasting and Web Search Portals",
+      "authority": "Smartlogic",
+      "authorityValue": "38ee195d-ebdd-48a9-af4b-c8a322e7b04d",
+      "aliases": [
+        "Another Internet Publishing and Broadcasting and Web Search Portals"
+      ],
+      "industryIdentifier": "519131"
+    }
+  ]
+}

--- a/db/fixtures/NAICS-Industry-Classification-49da878c-67ce-4343-9a09-a4a767e584a2.json
+++ b/db/fixtures/NAICS-Industry-Classification-49da878c-67ce-4343-9a09-a4a767e584a2.json
@@ -1,0 +1,22 @@
+{
+  "prefUUID": "49da878c-67ce-4343-9a09-a4a767e584a2",
+  "prefLabel": "Internet Publishing and Broadcasting and Web Search Portals",
+  "type": "NAICSIndustryClassification",
+  "aliases": [
+    "Internet Publishing and Broadcasting and Web Search Portals"
+  ],
+  "industryIdentifier": "519130",
+  "sourceRepresentations": [
+    {
+      "uuid": "49da878c-67ce-4343-9a09-a4a767e584a2",
+      "type": "NAICSIndustryClassification",
+      "prefLabel": "Internet Publishing and Broadcasting and Web Search Portals",
+      "authority": "Smartlogic",
+      "authorityValue": "49da878c-67ce-4343-9a09-a4a767e584a2",
+      "aliases": [
+        "Internet Publishing and Broadcasting and Web Search Portals"
+      ],
+      "industryIdentifier": "519130"
+    }
+  ]
+}

--- a/db/fixtures/Organisation-Fakebook-eac853f5-3859-4c08-8540-55e043719400-Factset.json
+++ b/db/fixtures/Organisation-Fakebook-eac853f5-3859-4c08-8540-55e043719400-Factset.json
@@ -6,6 +6,16 @@
         "Fakebook Inc"
     ],
     "aggregateHash": "7906209953307351514",
+    "naicsIndustryClassifications": [
+        {
+            "uuid": "49da878c-67ce-4343-9a09-a4a767e584a2",
+            "rank": 1
+        },
+        {
+            "uuid": "38ee195d-ebdd-48a9-af4b-c8a322e7b04d",
+            "rank": 2
+        }
+    ],
     "sourceRepresentations": [
         {
             "uuid": "eac853f5-3859-4c08-8540-55e043719400",
@@ -19,7 +29,17 @@
             "prefLabel": "Fakebook",
             "type": "Organisation",
             "authority": "FACTSET",
-            "authorityValue": "FACTSET1"
+            "authorityValue": "FACTSET1",
+            "naicsIndustryClassifications": [
+                {
+                    "uuid": "49da878c-67ce-4343-9a09-a4a767e584a2",
+                    "rank": 1
+                },
+                {
+                    "uuid": "38ee195d-ebdd-48a9-af4b-c8a322e7b04d",
+                    "rank": 2
+                }
+            ]
         }
     ],
     "alternativeIdentifiers": {

--- a/db/neo4j.go
+++ b/db/neo4j.go
@@ -33,8 +33,8 @@ type Concept struct {
 	APIURL                       string
 	Labels                       []string
 	LeiCode                      string
-	FactsetID                    string
-	FIGI                         string
+	FactsetIDs                   []string
+	FigiCodes                    []string
 	NAICSIndustryClassifications []NAICSIndustryClassification
 }
 
@@ -62,8 +62,8 @@ func (s *NeoService) Read(conceptType string, conceptCh chan Concept) (int, bool
 		WITH x, collect(DISTINCT CASE concept.authority WHEN 'FACTSET' THEN concept.authorityValue END) AS factsetIds,
 			collect(DISTINCT fi.figiCode) as figiCodes, collect(DISTINCT {id: naicsCanonical.industryIdentifier, rank: hasICRel.rank}) as naicsIndustryClassifications 
 		RETURN x.prefUUID AS Uuid, labels(x) AS Labels, x.prefLabel AS PrefLabel, x.leiCode AS leiCode,
-			reduce(s=head(factsetIds), n IN tail(factsetIds) | s + ';' + n) AS factsetId,
-			reduce(s=head(figiCodes), n IN tail(figiCodes) | s + ';' + n) AS FIGI,
+			factsetIds,
+			figiCodes,
 			naicsIndustryClassifications
 		`
 	}

--- a/db/neo4j.go
+++ b/db/neo4j.go
@@ -26,14 +26,15 @@ func NewNeoService(conn neoutils.NeoConnection, neoURL string) *NeoService {
 
 //Concept is the model for the data read from the data source
 type Concept struct {
-	Id        string
-	Uuid      string
-	PrefLabel string
-	ApiUrl    string
-	Labels    []string
-	LeiCode   string
-	FactsetId string
-	FIGI      string
+	ID                      string
+	UUID                    string
+	PrefLabel               string
+	APIURL                  string
+	Labels                  []string
+	LeiCode                 string
+	FactsetID               string
+	FIGI                    string
+	IndustryClassifications string
 }
 
 func (s *NeoService) Read(conceptType string, conceptCh chan Concept) (int, bool, error) {
@@ -84,8 +85,8 @@ func (s *NeoService) Read(conceptType string, conceptCh chan Concept) (int, bool
 	go func() {
 		defer close(conceptCh)
 		for _, c := range results {
-			c.ApiUrl = mapper.APIURL(c.Uuid, c.Labels, "")
-			c.Id = mapper.IDURL(c.Uuid)
+			c.APIURL = mapper.APIURL(c.UUID, c.Labels, "")
+			c.ID = mapper.IDURL(c.UUID)
 			conceptCh <- c
 		}
 	}()

--- a/db/neo4j.go
+++ b/db/neo4j.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/Financial-Times/neo-model-utils-go/mapper"
 	"github.com/Financial-Times/neo-utils-go/v2/neoutils"
@@ -26,15 +27,20 @@ func NewNeoService(conn neoutils.NeoConnection, neoURL string) *NeoService {
 
 //Concept is the model for the data read from the data source
 type Concept struct {
-	ID                      string
-	UUID                    string
-	PrefLabel               string
-	APIURL                  string
-	Labels                  []string
-	LeiCode                 string
-	FactsetID               string
-	FIGI                    string
-	IndustryClassifications string
+	ID                           string
+	UUID                         string
+	PrefLabel                    string
+	APIURL                       string
+	Labels                       []string
+	LeiCode                      string
+	FactsetID                    string
+	FIGI                         string
+	NAICSIndustryClassifications []NAICSIndustryClassification
+}
+
+type NAICSIndustryClassification struct {
+	IndustryIdentifier string `json:"id,omitempty"`
+	Rank               int    `json:"rank,omitempty"`
 }
 
 func (s *NeoService) Read(conceptType string, conceptCh chan Concept) (int, bool, error) {
@@ -52,11 +58,13 @@ func (s *NeoService) Read(conceptType string, conceptCh chan Concept) (int, bool
 		WITH DISTINCT x
 		MATCH (x)<-[:EQUIVALENT_TO]-(concept)
 		OPTIONAL MATCH (concept)<-[:ISSUED_BY]-(fi:FinancialInstrument)
+		OPTIONAL MATCH (concept)-[hasICRel:HAS_INDUSTRY_CLASSIFICATION]->(:NAICSIndustryClassification)-[:EQUIVALENT_TO]->(naicsCanonical:NAICSIndustryClassification)
 		WITH x, collect(DISTINCT CASE concept.authority WHEN 'FACTSET' THEN concept.authorityValue END) AS factsetIds,
-			collect(DISTINCT fi.figiCode) as figiCodes 
+			collect(DISTINCT fi.figiCode) as figiCodes, collect(DISTINCT {id: naicsCanonical.industryIdentifier, rank: hasICRel.rank}) as naicsIndustryClassifications 
 		RETURN x.prefUUID AS Uuid, labels(x) AS Labels, x.prefLabel AS PrefLabel, x.leiCode AS leiCode,
 			reduce(s=head(factsetIds), n IN tail(factsetIds) | s + ';' + n) AS factsetId,
-			reduce(s=head(figiCodes), n IN tail(figiCodes) | s + ';' + n) AS FIGI
+			reduce(s=head(figiCodes), n IN tail(figiCodes) | s + ';' + n) AS FIGI,
+			naicsIndustryClassifications
 		`
 	}
 	if conceptType == "Person" {
@@ -87,6 +95,7 @@ func (s *NeoService) Read(conceptType string, conceptCh chan Concept) (int, bool
 		for _, c := range results {
 			c.APIURL = mapper.APIURL(c.UUID, c.Labels, "")
 			c.ID = mapper.IDURL(c.UUID)
+			c.NAICSIndustryClassifications = cleanNAICS(c.NAICSIndustryClassifications)
 			conceptCh <- c
 		}
 	}()
@@ -99,4 +108,19 @@ func (s *NeoService) CheckConnectivity(conn neoutils.NeoConnection) (string, err
 		return "Could not connect to Neo", err
 	}
 	return "Neo could be reached", nil
+}
+
+func cleanNAICS(naics []NAICSIndustryClassification) []NAICSIndustryClassification {
+	var res []NAICSIndustryClassification
+	for _, ic := range naics {
+		if ic.IndustryIdentifier != "" {
+			res = append(res, ic)
+		}
+	}
+
+	sort.SliceStable(res, func(k, l int) bool {
+		return res[k].Rank < res[l].Rank
+	})
+
+	return res
 }

--- a/db/neo4j_integration_test.go
+++ b/db/neo4j_integration_test.go
@@ -23,18 +23,20 @@ import (
 )
 
 const (
-	contentUUID             = "a435b4ec-b207-4dce-ac0a-f8e7bbef310b"
-	brandParentUUID         = "dbb0bdae-1f0c-1a1a-b0cb-b2227cce2b54"
-	brandChildUUID          = "ff691bf8-8d92-1a1a-8326-c273400bff0b"
-	brandGrandChildUUID     = "ff691bf8-8d92-2a2a-8326-c273400bff0b"
-	financialInstrumentUUID = "77f613ad-1470-422c-bf7c-1dd4c3fd1693"
-	companyUUID             = "eac853f5-3859-4c08-8540-55e043719400"
-	organisationUUID        = "5d1510f8-2779-4b74-adab-0a5eb138fca6"
-	personUUID              = "b2fa511e-a031-4d52-b37d-72fd290b39ce"
-	personWithBrandUUID     = "9070a3f1-aa6d-48a7-9d97-f56a47513cef"
+	contentUUID                 = "a435b4ec-b207-4dce-ac0a-f8e7bbef310b"
+	brandParentUUID             = "dbb0bdae-1f0c-1a1a-b0cb-b2227cce2b54"
+	brandChildUUID              = "ff691bf8-8d92-1a1a-8326-c273400bff0b"
+	brandGrandChildUUID         = "ff691bf8-8d92-2a2a-8326-c273400bff0b"
+	financialInstrumentUUID     = "77f613ad-1470-422c-bf7c-1dd4c3fd1693"
+	companyUUID                 = "eac853f5-3859-4c08-8540-55e043719400"
+	organisationUUID            = "5d1510f8-2779-4b74-adab-0a5eb138fca6"
+	personUUID                  = "b2fa511e-a031-4d52-b37d-72fd290b39ce"
+	personWithBrandUUID         = "9070a3f1-aa6d-48a7-9d97-f56a47513cef"
+	industryClassificationUUID  = "49da878c-67ce-4343-9a09-a4a767e584a2"
+	industryClassificationUUID2 = "38ee195d-ebdd-48a9-af4b-c8a322e7b04d"
 )
 
-var allUUIDs = []string{contentUUID, brandParentUUID, brandChildUUID, brandGrandChildUUID, financialInstrumentUUID, companyUUID, organisationUUID, personUUID, personWithBrandUUID}
+var allUUIDs = []string{contentUUID, brandParentUUID, brandChildUUID, brandGrandChildUUID, financialInstrumentUUID, companyUUID, organisationUUID, personUUID, personWithBrandUUID, industryClassificationUUID, industryClassificationUUID2, "eac853f5-3859-4c08-8540-55e043719401", "eac853f5-3859-4c08-8540-55e043719402", "dbb0bdae-1f0c-11e4-b0cb-b2227cce2b54", "a7b4786c-aae9-3e3e-93a0-2c82a6383534", "22a60434-a9d5-3a38-a337-fdd904e99f6f"}
 
 func getDatabaseConnection(t *testing.T) neoutils.NeoConnection {
 	if testing.Short() {
@@ -258,6 +260,67 @@ func TestNeoService_ReadOrganisation(t *testing.T) {
 					assert.Equal(t, "PBLD0EJDB5FWOLXP3B76", c.LeiCode)
 					assert.Equal(t, "BB8000C3P0-R2D2", c.FIGI)
 					assert.Regexp(t, regexp.MustCompile(test.expectedFactsetRegex), c.FactsetID)
+				case <-time.After(3 * time.Second):
+					t.FailNow()
+				}
+			}
+		})
+	}
+}
+
+func TestNeoService_ReadOrganisationWithNAICS(t *testing.T) {
+	conn := getDatabaseConnection(t)
+	svc := concepts.NewConceptService(conn)
+	assert.NoError(t, svc.Initialise())
+
+	tests := []struct {
+		name          string
+		knownUUIDs    []string
+		expectedNAICS []NAICSIndustryClassification
+	}{
+		{
+			name:       "Organisation with 1 known and 1 unknown NAICS industry classification",
+			knownUUIDs: []string{industryClassificationUUID},
+			expectedNAICS: []NAICSIndustryClassification{
+				{IndustryIdentifier: "519130", Rank: 1},
+			},
+		},
+		{
+			name:       "Organisation with multiple known NAICS industry classifications",
+			knownUUIDs: []string{industryClassificationUUID, industryClassificationUUID2},
+			expectedNAICS: []NAICSIndustryClassification{
+				{IndustryIdentifier: "519130", Rank: 1}, {IndustryIdentifier: "519131", Rank: 2},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cleanDB(t, conn)
+			writeJSONToConceptService(t, &svc, fmt.Sprintf("./fixtures/Organisation-Fakebook-%s-Factset.json", companyUUID))
+			for _, id := range test.knownUUIDs {
+				writeJSONToConceptService(t, &svc, fmt.Sprintf("./fixtures/NAICS-Industry-Classification-%s.json", id))
+			}
+
+			writeContent(t, conn)
+			writeAnnotation(t, conn, fmt.Sprintf("./fixtures/Annotations-%s-org.json", contentUUID), "v2")
+			neoSvc := NewNeoService(conn, "not-needed")
+
+			conceptCh := make(chan Concept)
+			count, found, err := neoSvc.Read("Organisation", conceptCh)
+
+			assert.NoError(t, err, "Error reading from Neo")
+			assert.True(t, found)
+			assert.Equal(t, 1, count)
+		waitLoop:
+			for {
+				select {
+				case c, open := <-conceptCh:
+					if !open {
+						break waitLoop
+					}
+
+					assert.Equal(t, test.expectedNAICS, c.NAICSIndustryClassifications)
 				case <-time.After(3 * time.Second):
 					t.FailNow()
 				}

--- a/db/neo4j_integration_test.go
+++ b/db/neo4j_integration_test.go
@@ -77,9 +77,9 @@ waitLoop:
 			if !open {
 				break waitLoop
 			}
-			assert.Equal(t, "ff691bf8-8d92-1a1a-8326-c273400bff0b", c.Uuid)
-			assert.Equal(t, "http://api.ft.com/things/ff691bf8-8d92-1a1a-8326-c273400bff0b", c.Id)
-			assert.Equal(t, "http://api.ft.com/brands/ff691bf8-8d92-1a1a-8326-c273400bff0b", c.ApiUrl)
+			assert.Equal(t, "ff691bf8-8d92-1a1a-8326-c273400bff0b", c.UUID)
+			assert.Equal(t, "http://api.ft.com/things/ff691bf8-8d92-1a1a-8326-c273400bff0b", c.ID)
+			assert.Equal(t, "http://api.ft.com/brands/ff691bf8-8d92-1a1a-8326-c273400bff0b", c.APIURL)
 			assert.Equal(t, "Business School video", c.PrefLabel)
 			assertListContainsAll(t, []string{"Thing", "Concept", "Brand", "Classification"}, c.Labels)
 			assert.Empty(t, c.LeiCode)
@@ -187,9 +187,9 @@ waitLoop:
 			if !open {
 				break waitLoop
 			}
-			assert.Equal(t, "ff691bf8-8d92-1a1a-8326-c273400bff0b", c.Uuid)
-			assert.Equal(t, "http://api.ft.com/things/ff691bf8-8d92-1a1a-8326-c273400bff0b", c.Id)
-			assert.Equal(t, "http://api.ft.com/brands/ff691bf8-8d92-1a1a-8326-c273400bff0b", c.ApiUrl)
+			assert.Equal(t, "ff691bf8-8d92-1a1a-8326-c273400bff0b", c.UUID)
+			assert.Equal(t, "http://api.ft.com/things/ff691bf8-8d92-1a1a-8326-c273400bff0b", c.ID)
+			assert.Equal(t, "http://api.ft.com/brands/ff691bf8-8d92-1a1a-8326-c273400bff0b", c.APIURL)
 			assert.Equal(t, "Business School video", c.PrefLabel)
 			assertListContainsAll(t, []string{"Thing", "Concept", "Brand", "Classification"}, c.Labels)
 			assert.Empty(t, c.LeiCode)
@@ -250,14 +250,14 @@ func TestNeoService_ReadOrganisation(t *testing.T) {
 					if !open {
 						break waitLoop
 					}
-					assert.Equal(t, "eac853f5-3859-4c08-8540-55e043719400", c.Uuid)
-					assert.Equal(t, "http://api.ft.com/things/eac853f5-3859-4c08-8540-55e043719400", c.Id)
-					assert.Equal(t, "http://api.ft.com/organisations/eac853f5-3859-4c08-8540-55e043719400", c.ApiUrl)
+					assert.Equal(t, "eac853f5-3859-4c08-8540-55e043719400", c.UUID)
+					assert.Equal(t, "http://api.ft.com/things/eac853f5-3859-4c08-8540-55e043719400", c.ID)
+					assert.Equal(t, "http://api.ft.com/organisations/eac853f5-3859-4c08-8540-55e043719400", c.APIURL)
 					assert.Equal(t, "Fakebook", c.PrefLabel)
 					assertListContainsAll(t, []string{"Thing", "Concept", "Organisation", "PublicCompany", "Company"}, c.Labels)
 					assert.Equal(t, "PBLD0EJDB5FWOLXP3B76", c.LeiCode)
 					assert.Equal(t, "BB8000C3P0-R2D2", c.FIGI)
-					assert.Regexp(t, regexp.MustCompile(test.expectedFactsetRegex), c.FactsetId)
+					assert.Regexp(t, regexp.MustCompile(test.expectedFactsetRegex), c.FactsetID)
 				case <-time.After(3 * time.Second):
 					t.FailNow()
 				}
@@ -332,9 +332,9 @@ func TestNeoService_ReadPerson(t *testing.T) {
 						if !open {
 							break waitLoop
 						}
-						assert.Equal(t, test.uuid, c.Uuid)
-						assert.Equal(t, "http://api.ft.com/things/"+test.uuid, c.Id)
-						assert.Equal(t, "http://api.ft.com/people/"+test.uuid, c.ApiUrl)
+						assert.Equal(t, test.uuid, c.UUID)
+						assert.Equal(t, "http://api.ft.com/things/"+test.uuid, c.ID)
+						assert.Equal(t, "http://api.ft.com/people/"+test.uuid, c.APIURL)
 						assert.Equal(t, test.expectedPrefLabel, c.PrefLabel)
 						assertListContainsAll(t, []string{"Thing", "Concept", "Person"}, c.Labels)
 					case <-time.After(3 * time.Second):

--- a/docker-compose-tests.yml
+++ b/docker-compose-tests.yml
@@ -1,0 +1,20 @@
+version: '3'
+services:
+  test-runner:
+    build:
+      context: .
+      dockerfile: Dockerfile.tests
+    container_name: test-runner
+    environment:
+      - NEO4J_TEST_URL=http://neo4j:7474/db/data
+    command: ["go", "test", "-mod=readonly", "-race", "-tags=integration", "./..."]
+    depends_on:
+      - neo4j
+  neo4j:
+    image: neo4j:3.4.10-enterprise
+    environment:
+          NEO4J_AUTH: none
+          NEO4J_ACCEPT_LICENSE_AGREEMENT: "yes"
+    ports:
+      - "7474:7474"
+      - "7687:7687"

--- a/export/csv.go
+++ b/export/csv.go
@@ -40,16 +40,7 @@ func (e *CsvExporter) Prepare(conceptTypes []string) error {
 }
 
 func (e *CsvExporter) Write(c db.Concept, conceptType, tid string) error {
-	var rec []string
-	rec = append(rec, c.ID)
-	rec = append(rec, c.PrefLabel)
-	rec = append(rec, c.APIURL)
-	if conceptType == "Organisation" {
-		rec = append(rec, c.LeiCode)
-		rec = append(rec, c.FactsetID)
-		rec = append(rec, c.FIGI)
-	}
-
+	rec := conceptToCSVRecord(c, conceptType)
 	return e.Writer[conceptType].Writer.Write(rec)
 }
 
@@ -62,4 +53,18 @@ func getHeader(conceptType string) []string {
 		return []string{"id", "prefLabel", "apiUrl", "leiCode", "factsetId", "FIGI"}
 	}
 	return []string{"id", "prefLabel", "apiUrl"}
+}
+
+func conceptToCSVRecord(c db.Concept, conceptType string) []string {
+	var rec []string
+	rec = append(rec, c.ID)
+	rec = append(rec, c.PrefLabel)
+	rec = append(rec, c.APIURL)
+	if conceptType == "Organisation" {
+		rec = append(rec, c.LeiCode)
+		rec = append(rec, c.FactsetID)
+		rec = append(rec, c.FIGI)
+	}
+
+	return rec
 }

--- a/export/csv.go
+++ b/export/csv.go
@@ -63,8 +63,8 @@ func conceptToCSVRecord(c db.Concept, conceptType string) []string {
 	rec = append(rec, c.APIURL)
 	if conceptType == "Organisation" {
 		rec = append(rec, c.LeiCode)
-		rec = append(rec, c.FactsetID)
-		rec = append(rec, c.FIGI)
+		rec = append(rec, strings.Join(c.FactsetIDs, ";"))
+		rec = append(rec, strings.Join(c.FigiCodes, ";"))
 
 		var naics []string
 		for _, ic := range c.NAICSIndustryClassifications {

--- a/export/csv.go
+++ b/export/csv.go
@@ -3,6 +3,7 @@ package export
 import (
 	"bytes"
 	"encoding/csv"
+	"strings"
 
 	"github.com/Financial-Times/concept-exporter/db"
 )
@@ -50,7 +51,7 @@ func (e *CsvExporter) GetFileName(conceptType string) string {
 
 func getHeader(conceptType string) []string {
 	if conceptType == "Organisation" {
-		return []string{"id", "prefLabel", "apiUrl", "leiCode", "factsetId", "FIGI"}
+		return []string{"id", "prefLabel", "apiUrl", "leiCode", "factsetId", "FIGI", "NAICS"}
 	}
 	return []string{"id", "prefLabel", "apiUrl"}
 }
@@ -64,6 +65,13 @@ func conceptToCSVRecord(c db.Concept, conceptType string) []string {
 		rec = append(rec, c.LeiCode)
 		rec = append(rec, c.FactsetID)
 		rec = append(rec, c.FIGI)
+
+		var naics []string
+		for _, ic := range c.NAICSIndustryClassifications {
+			naics = append(naics, ic.IndustryIdentifier)
+		}
+
+		rec = append(rec, strings.Join(naics, ";"))
 	}
 
 	return rec

--- a/export/csv.go
+++ b/export/csv.go
@@ -41,12 +41,12 @@ func (e *CsvExporter) Prepare(conceptTypes []string) error {
 
 func (e *CsvExporter) Write(c db.Concept, conceptType, tid string) error {
 	var rec []string
-	rec = append(rec, c.Id)
+	rec = append(rec, c.ID)
 	rec = append(rec, c.PrefLabel)
-	rec = append(rec, c.ApiUrl)
+	rec = append(rec, c.APIURL)
 	if conceptType == "Organisation" {
 		rec = append(rec, c.LeiCode)
-		rec = append(rec, c.FactsetId)
+		rec = append(rec, c.FactsetID)
 		rec = append(rec, c.FIGI)
 	}
 

--- a/export/csv_test.go
+++ b/export/csv_test.go
@@ -41,12 +41,12 @@ func TestConceptToCSVRecord(t *testing.T) {
 		},
 		"transform organisation": {
 			concept: db.Concept{
-				ID:        "http://api.ft.com/things/eac853f5-3859-4c08-8540-55e043719400",
-				PrefLabel: "Fakebook",
-				APIURL:    "http://api.ft.com/organisations/eac853f5-3859-4c08-8540-55e043719400",
-				LeiCode:   "PBLD0EJDB5FWOLXP3B76",
-				FactsetID: "FACTSET1;FACTSET1",
-				FIGI:      "BB8000C3P0-R2D2",
+				ID:         "http://api.ft.com/things/eac853f5-3859-4c08-8540-55e043719400",
+				PrefLabel:  "Fakebook",
+				APIURL:     "http://api.ft.com/organisations/eac853f5-3859-4c08-8540-55e043719400",
+				LeiCode:    "PBLD0EJDB5FWOLXP3B76",
+				FactsetIDs: []string{"FACTSET1", "FACTSET2"},
+				FigiCodes:  []string{"BB8000C3P0-R2D2"},
 				NAICSIndustryClassifications: []db.NAICSIndustryClassification{
 					{IndustryIdentifier: "519130", Rank: 1},
 					{IndustryIdentifier: "519131", Rank: 2},
@@ -58,7 +58,7 @@ func TestConceptToCSVRecord(t *testing.T) {
 				"Fakebook",
 				"http://api.ft.com/organisations/eac853f5-3859-4c08-8540-55e043719400",
 				"PBLD0EJDB5FWOLXP3B76",
-				"FACTSET1;FACTSET1",
+				"FACTSET1;FACTSET2",
 				"BB8000C3P0-R2D2",
 				"519130;519131",
 			},

--- a/export/csv_test.go
+++ b/export/csv_test.go
@@ -1,0 +1,74 @@
+package export
+
+import (
+	"testing"
+
+	"github.com/Financial-Times/concept-exporter/db"
+	"github.com/stretchr/testify/assert"
+)
+
+var supportedConceptTypes = []string{"Brand", "Topic", "Location", "Person", "Organisation"}
+
+func TestGetHeader(t *testing.T) {
+	for _, conceptType := range supportedConceptTypes {
+		header := getHeader(conceptType)
+		if conceptType == "Organisation" {
+			assert.Equal(t, []string{"id", "prefLabel", "apiUrl", "leiCode", "factsetId", "FIGI", "NAICS"}, header)
+		} else {
+			assert.Equal(t, []string{"id", "prefLabel", "apiUrl"}, header)
+		}
+	}
+}
+
+func TestConceptToCSVRecord(t *testing.T) {
+	tests := map[string]struct {
+		concept     db.Concept
+		conceptType string
+		expected    []string
+	}{
+		"transform brand": {
+			concept: db.Concept{
+				ID:        "http://api.ft.com/things/dbb0bdae-1f0c-1a1a-b0cb-b2227cce2b54",
+				PrefLabel: "Financial Times",
+				APIURL:    "http://api.ft.com/brands/dbb0bdae-1f0c-1a1a-b0cb-b2227cce2b54",
+			},
+			conceptType: "Brand",
+			expected: []string{
+				"http://api.ft.com/things/dbb0bdae-1f0c-1a1a-b0cb-b2227cce2b54",
+				"Financial Times",
+				"http://api.ft.com/brands/dbb0bdae-1f0c-1a1a-b0cb-b2227cce2b54",
+			},
+		},
+		"transform organisation": {
+			concept: db.Concept{
+				ID:        "http://api.ft.com/things/eac853f5-3859-4c08-8540-55e043719400",
+				PrefLabel: "Fakebook",
+				APIURL:    "http://api.ft.com/organisations/eac853f5-3859-4c08-8540-55e043719400",
+				LeiCode:   "PBLD0EJDB5FWOLXP3B76",
+				FactsetID: "FACTSET1;FACTSET1",
+				FIGI:      "BB8000C3P0-R2D2",
+				NAICSIndustryClassifications: []db.NAICSIndustryClassification{
+					{IndustryIdentifier: "519130", Rank: 1},
+					{IndustryIdentifier: "519131", Rank: 2},
+				},
+			},
+			conceptType: "Organisation",
+			expected: []string{
+				"http://api.ft.com/things/eac853f5-3859-4c08-8540-55e043719400",
+				"Fakebook",
+				"http://api.ft.com/organisations/eac853f5-3859-4c08-8540-55e043719400",
+				"PBLD0EJDB5FWOLXP3B76",
+				"FACTSET1;FACTSET1",
+				"BB8000C3P0-R2D2",
+				"519130;519131",
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			result := conceptToCSVRecord(test.concept, test.conceptType)
+			assert.Equal(t, test.expected, result)
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -6,12 +6,12 @@ require (
 	github.com/Financial-Times/annotations-rw-neo4j/v3 v3.2.0
 	github.com/Financial-Times/api-endpoint v0.0.0-20170713111258-802a63542ff0 // indirect
 	github.com/Financial-Times/base-ft-rw-app-go v0.0.0-20171010162315-74eab27b0c6d
-	github.com/Financial-Times/concepts-rw-neo4j v1.23.2
+	github.com/Financial-Times/concepts-rw-neo4j v1.27.0
 	github.com/Financial-Times/content-rw-neo4j v1.0.3-0.20171011115956-641ce08b0417
 	github.com/Financial-Times/go-fthealth v0.0.0-20181009114238-ca83ad65381f
 	github.com/Financial-Times/go-logger/v2 v2.0.1
 	github.com/Financial-Times/http-handlers-go/v2 v2.1.0
-	github.com/Financial-Times/neo-model-utils-go v0.0.0-20180712095719-aea1e95c8305
+	github.com/Financial-Times/neo-model-utils-go v1.0.0
 	github.com/Financial-Times/neo-utils-go/v2 v2.0.0
 	github.com/Financial-Times/service-status-go v0.0.0-20160323111542-3f5199736a3d
 	github.com/Financial-Times/transactionid-utils-go v0.2.0
@@ -27,7 +27,7 @@ require (
 	github.com/rcrowley/go-metrics v0.0.0-20190826022208-cac0b30c2563
 	github.com/sethgrid/pester v0.0.0-20190127155807-68a33a018ad0
 	github.com/sirupsen/logrus v1.4.2 // indirect
-	github.com/stretchr/testify v1.4.0
+	github.com/stretchr/testify v1.6.1
 	go4.org v0.0.0-20191010144846-132d2879e1e9 // indirect
 	golang.org/x/net v0.0.0-20191119073136-fc4aabc6c914 // indirect
 	golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e // indirect

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,8 @@ github.com/Financial-Times/api-endpoint v0.0.0-20170713111258-802a63542ff0 h1:Le
 github.com/Financial-Times/api-endpoint v0.0.0-20170713111258-802a63542ff0/go.mod h1:qpLKxPcad+pl1zmQAMDCxwf4pDp+ggRmvKDDI5s6ZjU=
 github.com/Financial-Times/base-ft-rw-app-go v0.0.0-20171010162315-74eab27b0c6d h1:p6erLN58Pymv7XgCzOnZaH2ZHJ+vNqH7dPPP2p6qNwo=
 github.com/Financial-Times/base-ft-rw-app-go v0.0.0-20171010162315-74eab27b0c6d/go.mod h1:olJfPwdMPV/SJUrv4J+9gI9yaj7d24vXF2GNisFRCOg=
-github.com/Financial-Times/concepts-rw-neo4j v1.23.2 h1:lYRzr3ZzKxKR2qLW0iVKdvjoKEGx+OWAQNvW2YIGuRY=
-github.com/Financial-Times/concepts-rw-neo4j v1.23.2/go.mod h1:5DkBQpYrZHoo3Qm0KNRfdX7W8C8LrbkpC5g1zCxvl0g=
+github.com/Financial-Times/concepts-rw-neo4j v1.27.0 h1:uQdTA06e6aDxRBxIH+ZptkNDJ/bJX2o1IJTu81mwM9k=
+github.com/Financial-Times/concepts-rw-neo4j v1.27.0/go.mod h1:dzsMkapEPuXLoq6/fERZ6Se3qh/Af9/taweycMnkvsI=
 github.com/Financial-Times/content-rw-neo4j v1.0.3-0.20171011115956-641ce08b0417 h1:LBYhP5ZsLR52Ylp1zYnxnWOsyKnZQHnj7Un9/ujtiqI=
 github.com/Financial-Times/content-rw-neo4j v1.0.3-0.20171011115956-641ce08b0417/go.mod h1:TU5tuPvdTnZ2yhW2+BAlXPk/bqh1B5PBqwqPiYyRTqE=
 github.com/Financial-Times/go-fthealth v0.0.0-20171204124831-1b007e2b37b7/go.mod h1:gpAzq6W5rCheYlY32JOIxS/VjVcYHbC2PkMzQngHT9c=
@@ -25,6 +25,8 @@ github.com/Financial-Times/kafka v0.0.0-20181214115819-fddecb2b8f89/go.mod h1:9i
 github.com/Financial-Times/kafka-client-go v0.0.0-20181214120216-c3a1941e42a4/go.mod h1:IRxo6zPqM44uCWpM7YBkm5o9lOxwPgR0/WvCX0KcV/Y=
 github.com/Financial-Times/neo-model-utils-go v0.0.0-20180712095719-aea1e95c8305 h1:ob+VRuAq7QGfqT4ccoH5Ru0nfnBmjmNgUEaLzXTzUNw=
 github.com/Financial-Times/neo-model-utils-go v0.0.0-20180712095719-aea1e95c8305/go.mod h1:HdCuBcOftPWj3SBix/6H9NbPQpur9F7stSF0MEROMcU=
+github.com/Financial-Times/neo-model-utils-go v1.0.0 h1:0iTxDtXKkJ9vYQDE73KM/+ghtFLdq0U6bQPdiwaSEaQ=
+github.com/Financial-Times/neo-model-utils-go v1.0.0/go.mod h1:D5ny/A+002uCPCZbtP/E+qpY3//gYJzHw6sqqBUm2Lc=
 github.com/Financial-Times/neo-utils-go v0.0.0-20180807105745-1fe6ae2f38f3 h1:oH+0BiMwcZVV1zwYm4f/jybJ9LhzrQn1Y4WwbIpwQ+s=
 github.com/Financial-Times/neo-utils-go v0.0.0-20180807105745-1fe6ae2f38f3/go.mod h1:LF1qICt4PuWDINYtXL4WXU595WTKReIBwV6obcncNBI=
 github.com/Financial-Times/neo-utils-go/v2 v2.0.0 h1:q/cOJHehYmY0jgTIkdO3kxPBt3GeYCqaL3MGYfAdYBw=
@@ -54,6 +56,8 @@ github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
+github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/uuid v1.0.0 h1:b4Gk+7WdP/d3HZH8EJsZpvV7EtDOgaZLtnaNGIu1adA=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
@@ -129,8 +133,8 @@ github.com/stretchr/testify v0.0.0-20170809224252-890a5c3458b4/go.mod h1:a8OnRci
 github.com/stretchr/testify v1.1.4/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
-github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/twinj/uuid v1.0.0/go.mod h1:mMgcE1RHFUFqe5AfiwlINXisXfDGro23fWdPUfOMjRY=
 github.com/wvanbergen/kazoo-go v0.0.0-20180202103751-f72d8611297a/go.mod h1:vQQATAGxVK20DC1rRubTJbZDDhhpA4QfU02pMdPxGO4=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
@@ -167,6 +171,8 @@ golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/time v0.0.0-20190921001708-c4c64cad1fd0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/airbrake/gobrake.v2 v2.0.9 h1:7z2uVWwn7oVeeugY1DtlPAy5H+KYgB1KeKTnqjNatLo=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
@@ -187,7 +193,7 @@ gopkg.in/jmcvetta/napping.v3 v3.2.0/go.mod h1:0dPR4/IGM4+xGT+e48O2yJlg6qofrONCtE
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
-gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.7 h1:VUgggvou5XRW9mHwD/yXxIYSMtY0zoKQf/v226p2nyo=
 gopkg.in/yaml.v2 v2.2.7/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
# Description

## What

Add support for exporting NAICS industry classifications for concepts with type Organisation.

## Why

[JIRA ticket](https://financialtimes.atlassian.net/browse/UPPSF-1961).

## Anything, in particular, you'd like to highlight to reviewers

The NAICS field should be present only for  concepts with type Organisation and its values should be a list of NAICS industry identifiers sorted by their rank separated by semicolon e.g. `524113;524114;524126;523999`.

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [X] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
